### PR TITLE
Force docutils version to avoid build failure w/ > 0.16

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx
 sphinx_rtd_theme
 recommonmark
 sphinx-markdown-tables==0.0.6
+docutils==0.16


### PR DESCRIPTION
Warning from previous build that resulted in error in docutils==0.18, see ([Build #15097412](https://readthedocs.org/projects/casper-tutorials/builds/15097412/)) for error:
/home/docs/checkouts/readthedocs.org/user_builds/casper-tutorials/envs/latest/lib/python3.7/site-packages/sphinx/builders/latex/__init__.py:201: FutureWarning: 
   The iterable returned by Node.traverse()
   will become an iterator instead of a list in Docutils > 0.16.
  if toctrees[0].get('maxdepth') > 0:

