### PR TITLE
Extend sphinxcontrib.video to skip video node in latex generation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,6 +128,26 @@ htmlhelp_basename = 'CASPERTutorialsdoc'
 
 # -- Options for LaTeX output ------------------------------------------------
 
+# Embedding videos into a PDF is not supported. Extend the Sphinx.writer.latex
+# to just skip the node. This will result in nothing being placed in the
+# resulting LaTeX and output PDF
+from docutils import nodes
+from sphinxcontrib.video import video
+from sphinx.writers import latex
+
+def visit_video(self, node):
+    self.builder.warn('using "video" inside a PDF is not supported. This node '
+      'will be skipped resulting in no output to the LaTeX or PDF document. '
+      'Consider extending the video node to instead place a still image a '
+      'frame for the video.')
+    raise nodes.SkipNode
+
+def depart_video(self, node):
+    pass
+
+def setup(app):
+    app.add_node(video, latex=(visit_video, depart_video), override=True)
+
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #


### PR DESCRIPTION
The previous merge built HTML source fine, but the LaTeX failed. This is due to the videos added in the 100GbE tutorial to demonstrate the scripts running and the expected output.

Could have removed the videos in favor of a still image. Instead inject an extension of the sphinx.contrib video extension to have latex just skip the video nodes. This does result in having nothing in the place of the node in the output PDF but I am willing to give that up for now.